### PR TITLE
Fix/corsError

### DIFF
--- a/server/src/events/events.gateway.ts
+++ b/server/src/events/events.gateway.ts
@@ -15,6 +15,7 @@ import { Server, Socket } from 'socket.io';
     origin: [
       'http://localhost:5173',
       'https://bomberman-9t7ips6ev-khkmgch.vercel.app',
+      '*'
     ],
   },
 })


### PR DESCRIPTION
以下のエラーを解消するための修正

Access to XMLHttpRequest at 'https://bomberman-hv7prm7vnq-an.a.run.app/socket.io/?EIO=4&transport=polling&t=OP5wlMS' from origin 'https://bomberman-fawn.vercel.app' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.